### PR TITLE
Making config file location configurable via env variable

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
     // Server
     "appconfig": true,
     "appdata": true,
+    "CONFIGPATH": true,
     "ROOTPATH": true,
     "SERVERPATH": true,
     "IS_DEBUG": true

--- a/server/agent.js
+++ b/server/agent.js
@@ -7,9 +7,17 @@
 const path = require('path')
 const ROOTPATH = process.cwd()
 const SERVERPATH = path.join(ROOTPATH, 'server')
+const CONFIGPATH = path.join(
+  process.env.CONFIG_PATH
+    ? process.env.CONFIG_PATH.endsWith('/')
+      ? process.env.CONFIG_PATH.slice(0, -1)
+      : process.env.CONFIG_PATH
+    : ROOTPATH, 'config.yml'
+)
 
 global.ROOTPATH = ROOTPATH
 global.SERVERPATH = SERVERPATH
+global.CONFIGPATH = CONFIGPATH
 const IS_DEBUG = process.env.NODE_ENV === 'development'
 
 let appconf = require('./libs/config')()

--- a/server/configure.js
+++ b/server/configure.js
@@ -5,6 +5,13 @@ module.exports = (port, spinner) => {
 
   const ROOTPATH = process.cwd()
   const SERVERPATH = path.join(ROOTPATH, 'server')
+  const CONFIGPATH = path.join(
+    process.env.CONFIG_PATH
+      ? process.env.CONFIG_PATH.endsWith('/')
+        ? process.env.CONFIG_PATH.slice(0, -1)
+        : process.env.CONFIG_PATH
+      : ROOTPATH, 'config.yml'
+  )
   const IS_DEBUG = process.env.NODE_ENV === 'development'
 
   // ----------------------------------------
@@ -59,7 +66,7 @@ module.exports = (port, spinner) => {
     let conf = {}
     try {
       langs = yaml.safeLoad(fs.readFileSync(path.join(SERVERPATH, 'app/data.yml'), 'utf8')).langs
-      conf = yaml.safeLoad(fs.readFileSync(path.join(ROOTPATH, 'config.yml'), 'utf8'))
+      conf = yaml.safeLoad(fs.readFileSync(CONFIGPATH, 'utf8'))
     } catch (err) {
       console.error(err)
     }
@@ -118,7 +125,7 @@ module.exports = (port, spinner) => {
       () => {
         let fs = require('fs')
         return Promise.try(() => {
-          fs.accessSync(path.join(ROOTPATH, 'config.yml'), (fs.constants || fs).W_OK)
+          fs.accessSync(CONFIGPATH, (fs.constants || fs).W_OK)
         }).catch(err => { // eslint-disable-line handle-callback-err
           throw new Error('config.yml file is not writable by Node.js process or was not created properly.')
         }).return('config.yml is writable by the setup process.')
@@ -315,7 +322,7 @@ module.exports = (port, spinner) => {
           }
         })
       }),
-      fs.readFileAsync(path.join(ROOTPATH, 'config.yml'), 'utf8').then(confRaw => {
+      fs.readFileAsync(CONFIGPATH).then(confRaw => {
         let conf = yaml.safeLoad(confRaw)
         conf.title = req.body.title
         conf.host = req.body.host
@@ -356,7 +363,7 @@ module.exports = (port, spinner) => {
         return crypto.randomBytesAsync(32).then(buf => {
           conf.sessionSecret = buf.toString('hex')
           confRaw = yaml.safeDump(conf)
-          return fs.writeFileAsync(path.join(ROOTPATH, 'config.yml'), confRaw)
+          return fs.writeFileAsync(CONFIGPATH, confRaw)
         })
       })
     ).then(() => {

--- a/server/index.js
+++ b/server/index.js
@@ -9,9 +9,17 @@
 const path = require('path')
 const ROOTPATH = process.cwd()
 const SERVERPATH = path.join(ROOTPATH, 'server')
+const CONFIGPATH = path.join(
+  process.env.CONFIG_PATH
+    ? process.env.CONFIG_PATH.endsWith('/')
+      ? process.env.CONFIG_PATH.slice(0, -1)
+      : process.env.CONFIG_PATH
+    : ROOTPATH, 'config.yml'
+)
 
 global.ROOTPATH = ROOTPATH
 global.SERVERPATH = SERVERPATH
+global.CONFIGPATH = CONFIGPATH
 const IS_DEBUG = process.env.NODE_ENV === 'development'
 
 process.env.VIPS_WARNING = false

--- a/server/libs/config.js
+++ b/server/libs/config.js
@@ -14,7 +14,7 @@ const cfgHelper = require('../helpers/config')
  */
 module.exports = (confPaths) => {
   confPaths = _.defaults(confPaths, {
-    config: path.join(ROOTPATH, 'config.yml'),
+    config: CONFIGPATH,
     data: path.join(SERVERPATH, 'app/data.yml'),
     dataRegex: path.join(SERVERPATH, 'app/regex.js')
   })

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -3,10 +3,13 @@ FROM requarks/wiki:latest
 # Replace with your email address:
 ENV WIKI_ADMIN_EMAIL admin@example.com
 
-WORKDIR /var/wiki
+# Replace with the path to your config file
+ENV CONFIG_PATH /var/wiki
 
 # Replace your-config.yml with the path to your config file:
-ADD your-config.yml config.yml
+ADD your-config.yml ${CONFIG_PATH}/config.yml
+
+WORKDIR /var/wiki
 
 EXPOSE 3000
 ENTRYPOINT [ "node", "server" ]

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -19,5 +19,6 @@ services:
       - '80:3000'
     environment:
       WIKI_ADMIN_EMAIL: admin@example.com
+      CONFIG_PATH: /var/wiki
     volumes:
       - ./config.yml:/var/wiki/config.yml


### PR DESCRIPTION
Apologies if I needed to submit this as an idea first, but I thought others could potentially find this useful. If the environment variable is not provided, then the application will default to expecting the config file at the ROOTPATH.

More detail:

I created this feature in a fork so that I can mount a config file stored in Azure File Storage as a volume in my container in an Azure App Service. Azure currently requires users to mount the entire storage container as a volume (instead of just mounting an individual file), therefore I wasn't able to mount it to /var/wiki since it would hide all the existing files.

My docker-compose file can now look like:

version: "3"
services:
  wikijs:
    image: <wiki image name>
    ports:
      - "80:80"
    environment:
      WIKI_ADMIN_EMAIL: <my email>
      CONFIG_PATH: /var/wiki/config
    volumes:
      - <azure storage identifier>:/var/wiki/config