### PR TITLE
Git committer name =/= author name

### DIFF
--- a/server/libs/git.js
+++ b/server/libs/git.js
@@ -289,7 +289,7 @@ module.exports = {
     let self = this
     let gitFilePath = entryPath + '.md'
 
-    return self._git.exec('log', ['--max-count=25', '--skip=1', '--format=format:%H %h %cI %cE %cN', '--', gitFilePath]).then((cProc) => {
+    return self._git.exec('log', ['--max-count=25', '--skip=1', '--format=format:%H %h %cI %aE %aN', '--', gitFilePath]).then((cProc) => {
       let out = cProc.stdout.toString()
       if (_.includes(out, 'fatal')) {
         let errorMsg = _.capitalize(_.head(_.split(_.replace(out, 'fatal: ', ''), ',')))


### PR DESCRIPTION
There seems to be a bit of a bug with the history feature of wiki.js

Whenever an edit is made, a git commit is made with the change to the repository with the author set to the user logged into wiki.js.

However, when the history is being displayed, the author is shown as the system git name/email rather than the wiki.js user that made the edit.

This is because the `%cE` and `%cN` format flags are used. As seen on https://git-scm.com/docs/pretty-formats, the author name and committer names can be different, and it is only the author names that are being changed by wiki.js when committing.

This pull request fixes the issue. Tested with git v.2.7.4
