### PR TITLE
Convert Heroku environment variable to a proper boolean value before …

### DIFF
--- a/server/init.js
+++ b/server/init.js
@@ -13,7 +13,14 @@ module.exports = {
    * Detect the most appropriate start mode
    */
   startDetect: function () {
-    if (process.env.WIKI_JS_HEROKU) {
+    let isHeroku = typeof process.env.WIKIJS_HEROKU === 'boolean'
+      ? process.env.WIKIJS_HEROKU
+      : (
+        process.env.WIKIJS_HEROKU === '1'
+        || process.env.WIKIJS_HEROKU === 'true'
+      )
+
+    if (isHeroku) {
       return this.startInHerokuMode()
     } else {
       return this.startInBackgroundMode()


### PR DESCRIPTION
Forces the `WIKIJS_HEROKU` environment variable into a boolean state. Resolves #229.

