### PR TITLE
Gracefully fail thumbnail generation

### DIFF
--- a/server/libs/uploads-agent.js
+++ b/server/libs/uploads-agent.js
@@ -238,6 +238,7 @@ module.exports = {
         .rgba(false)
         .write(destPath)
     })
+    .catch(err => console.error(err))
   },
 
   /**


### PR DESCRIPTION
Uploading images smaller than 150x150 pixels currently causes thumbnail generation to fail.

This issue has the side effect of preventing the folder tree view to render properly: if a folder called "images" contains a too small image, then only folders starting from letter 'a' to 'i' will show in the tree view. Other folders will be invisible from the folder tree.

This PR handles the case thumbnail generation fails, preventing the above side effect.